### PR TITLE
Docker gather logs

### DIFF
--- a/raspberrypi_central/webapp/docker-compose.prod.yml
+++ b/raspberrypi_central/webapp/docker-compose.prod.yml
@@ -1,10 +1,51 @@
 version: '3.7'
 
+x-logging: &loki-logging
+    driver: loki
+    options:
+        loki-url: "http://localhost:3100/api/prom/push"
+
 services:
-  web:
-    build: ./app
-    command: gunicorn hello_django.wsgi:application --bind 0.0.0.0:8000
-    ports:
-      - 8000:8000
-    env_file:
-      - ./.env.prod
+    rabbit:
+        logging: *loki-logging
+
+    rabbit_worker:
+        logging: *loki-logging
+
+    celery_beat:
+        logging: *loki-logging
+
+    web:
+        command: gunicorn hello_django.wsgi:application --bind 0.0.0.0:8000
+        ports:
+            - 8000:8000
+        env_file:
+            - .env
+        logging: *loki-logging
+
+    database:
+        logging: *loki-logging
+
+    mqtt:
+        logging: *loki-logging
+
+    python_process_mqtt:
+        logging: *loki-logging
+
+    loki:
+        image: grafana/loki:1.5.0
+        ports:
+            - "3100:3100"
+        command: -config.file=/etc/loki/local-config.yaml
+
+    promtail:
+        image: grafana/promtail:1.5.0
+        volumes:
+            - /var/log:/var/log
+        command: -config.file=/etc/promtail/docker-config.yaml
+
+    grafana:
+        image: grafana/grafana:7.1.3
+        ports:
+            - "3000:3000"
+

--- a/raspberrypi_central/webapp/docker-compose.yml
+++ b/raspberrypi_central/webapp/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3.7"
+
 services:
     rabbit:
         hostname: rabbit
@@ -13,6 +14,7 @@ services:
             rabbitmq:
             backend_mqtt:
                 ipv4_address: "172.19.0.101"
+
         # healthcheck:
         #     test: ["CMD", "wget", "-qO-", "http://localhost:15672"]
         #     interval: 30s
@@ -56,11 +58,7 @@ services:
             backend_mqtt:
                 ipv4_address: "172.19.0.50"
         env_file:
-          - .env
-        logging:
-            driver: loki
-            options:
-                loki-url: "http://localhost:3100/api/prom/push"
+            - .env
 
     database:
         image: postgres:12.3-alpine
@@ -100,22 +98,6 @@ services:
         env_file:
             - .env
 
-    loki:
-        image: grafana/loki:1.5.0
-        ports:
-            - "3100:3100"
-        command: -config.file=/etc/loki/local-config.yaml
-
-    promtail:
-        image: grafana/promtail:1.5.0
-        volumes:
-            - /var/log:/var/log
-        command: -config.file=/etc/promtail/docker-config.yaml
-
-    grafana:
-        image: grafana/grafana:7.1.3
-        ports:
-            - "3000:3000"
 networks:
     rabbitmq:
     webapp_backend:


### PR DESCRIPTION
## Tech stack
We won't use Elasticsearch database because it's way too heavy & not developer friendly to implement. For sure this is very powerful, but do we really need it? I don't think so.

We decided to uuse Loki & Grafana and, in the future maybe fluentd for little devices, like rpi 0. It seems to be easy to setup and lightweight.

## Requirements
- [x] In dev env I want all the log to be printed in my console. In prod env, I want my logs to go to Promtail/Loki.

To do so, we are using two docker-compose files. To run services for the production, you have to use the file.
`docker-compose -f docker-compose.yml -f docker-compose.prod.yml up`

##  Docker driver for Loki
[See the documentation.](https://grafana.com/docs/loki/latest/clients/docker-driver/)
> The Docker plugin must be installed on each Docker host that will be running containers you want to collect logs from.
To install:
```
docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
```
:warning: on the rpi, you have to install the armv7 version [(solution found here)](https://github.com/grafana/loki/issues/1973#issuecomment-645084374):
```
docker plugin install grafana/loki-docker-driver:arm-v7 --alias loki --grant-all-permissions
```
To check if it's ok:
```
docker plugin ls
```

Otherwise, if you didn't install the loki driver, when you will try to up your services, you will have this kind of errors:
```
ERROR: for web  Cannot create container for service web: logger: no log driver named 'loki' is registered
```

## Sources
[I have used the Loki repository for the base.](https://github.com/grafana/loki/tree/master/production)
[And I have used this article to improve the conf. It's a must read.](https://medium.com/@moeenz/dockerized-django-logging-via-grafana-loki-48464d13f8cb)

## Future: I may use fluentbit
On the PI zero W, Docker isn't working well with Python. And thus, I might simply install fluentbit, which is designed for small devices, to send my logs to my Promtail/Loki which are running on a more powerful PI (3 or 4).