### PR TITLE
feat(core): mqtt topic to update alarm status

### DIFF
--- a/core/app/alarm/mqtt/__init__.py
+++ b/core/app/alarm/mqtt/__init__.py
@@ -1,13 +1,20 @@
 from enum import Enum
+from utils.mqtt.mqtt_update_status import UpdateStatusDescriptor
 from alarm.mqtt.on_connected_services import OnConnectedCamera, OnConnectedCameraManager, OnConnectedObjectDetection, OnConnectedSpeakerHandler
+from alarm.mqtt.on_status_update import OnUpdateStatus, UpdateStatusPayload
 from utils.mqtt.mqtt_service import ServiceDescriptor
 from camera.mqtt import MqttServices as CameraMqttServices
+
 
 class MqttServices(Enum):
     OBJECT_DETECTION_MANAGER = 'object_detection_manager'
     OBJECT_DETECTION = 'object_detection'
 
     SPEAKER = 'speaker'
+
+
+class MqttUpdates(Enum):
+    ALARM = 'alarm'
 
 
 SERVICES = (
@@ -29,3 +36,10 @@ SERVICES = (
     ),
 )
 
+UPDATES = (
+    UpdateStatusDescriptor(
+        name=MqttUpdates.ALARM.value,
+        on_update=OnUpdateStatus,
+        payload_type=UpdateStatusPayload
+    ),
+)

--- a/core/app/alarm/mqtt/__init__.py
+++ b/core/app/alarm/mqtt/__init__.py
@@ -1,7 +1,5 @@
 from enum import Enum
-from utils.mqtt.mqtt_update_status import UpdateStatusDescriptor
 from alarm.mqtt.on_connected_services import OnConnectedCamera, OnConnectedCameraManager, OnConnectedObjectDetection, OnConnectedSpeakerHandler
-from alarm.mqtt.on_status_update import OnUpdateStatus, UpdateStatusPayload
 from utils.mqtt.mqtt_service import ServiceDescriptor
 from camera.mqtt import MqttServices as CameraMqttServices
 
@@ -11,10 +9,6 @@ class MqttServices(Enum):
     OBJECT_DETECTION = 'object_detection'
 
     SPEAKER = 'speaker'
-
-
-class MqttUpdates(Enum):
-    ALARM = 'alarm'
 
 
 SERVICES = (
@@ -36,10 +30,3 @@ SERVICES = (
     ),
 )
 
-UPDATES = (
-    UpdateStatusDescriptor(
-        name=MqttUpdates.ALARM.value,
-        on_update=OnUpdateStatus,
-        payload_type=UpdateStatusPayload
-    ),
-)

--- a/core/app/alarm/mqtt/mqtt_controller.py
+++ b/core/app/alarm/mqtt/mqtt_controller.py
@@ -202,13 +202,6 @@ def on_ping(message: MqttMessage) -> None:
 def register(mqtt: MQTT):
     mqtt.add_subscribe((
         MqttTopicFilterSubscription(
-            topic='update/status/+/+',
-            qos=1,
-            topics=[
-                MqttTopicSubscriptionBoolean('update/status/+/+', on_update_status),
-            ]
-        ),
-        MqttTopicFilterSubscription(
             topic='motion/#',
             qos=1,
             topics=[

--- a/core/app/alarm/mqtt/mqtt_controller.py
+++ b/core/app/alarm/mqtt/mqtt_controller.py
@@ -1,7 +1,3 @@
-from distutils.util import strtobool
-from alarm.models import AlarmStatus
-from devices.models import Device
-from alarm.use_cases.alarm_status import AlarmChangeStatus
 import dataclasses
 from dataclasses import dataclass, field
 import re
@@ -10,7 +6,7 @@ from typing import Optional, Sequence, Type, TypeVar
 
 from hello_django.loggers import LOGGER
 from utils.mqtt.mqtt_data import MqttTopicFilterSubscription, MqttTopicSubscription, \
-    MqttMessage, MqttTopicSubscriptionBoolean, MqttTopicSubscriptionJson
+    MqttMessage, MqttTopicSubscriptionJson
 from utils.mqtt import MQTT
 import alarm.tasks as tasks
 from alarm.business.alarm_ping import register_ping
@@ -76,21 +72,11 @@ class CameraMotionPayload:
     detections: Sequence[Detection]
 
 
-UPDATE_STATUS_MATCHER = r"^(?P<service>[\w]+)/(?P<device_id>[\w]+)"
-
-@dataclass
-class UpdateStatusTopic:
-    service: str
-    device_id: Optional[str] = None
-
-    _topic_matcher = UPDATE_STATUS_MATCHER
-
-
 @dataclass
 class CameraMotionTopic(CameraTopic):
     _topic_matcher = CAMERA_TOPIC_MATCHER
 
-T = TypeVar('T', Type[CameraMotionPictureTopic], Type[CameraMotionVideoTopic], Type[CameraMotionTopic], Type[UpdateStatusTopic])
+T = TypeVar('T', Type[CameraMotionPictureTopic], Type[CameraMotionVideoTopic], Type[CameraMotionTopic])
 
 def topic_regex(topic: str, t: T) -> Optional[T]:
     match = re.match(t._topic_matcher, topic) 

--- a/core/app/alarm/mqtt/mqtt_updates.py
+++ b/core/app/alarm/mqtt/mqtt_updates.py
@@ -1,0 +1,16 @@
+from enum import Enum
+from utils.mqtt.mqtt_update_status import UpdateStatusDescriptor
+from alarm.mqtt.on_status_update import OnUpdateStatus, UpdateStatusPayload
+
+
+class MqttUpdates(Enum):
+    ALARM = 'alarm'
+
+
+UPDATES = (
+    UpdateStatusDescriptor(
+        name=MqttUpdates.ALARM.value,
+        on_update=OnUpdateStatus,
+        payload_type=UpdateStatusPayload
+    ),
+)

--- a/core/app/alarm/mqtt/on_status_update.py
+++ b/core/app/alarm/mqtt/on_status_update.py
@@ -13,7 +13,7 @@ class UpdateStatusPayload:
     force: str = 'off'
 
     status_bool: Optional[bool] = field(init=False, default=None)
-    force_bool: Optional[bool] = field(init=False, default=None)
+    force_bool: Optional[bool] = field(init=False, default=False)
     toggle: Optional[bool] = field(init=False, default=None)
 
     def __post_init__(self):

--- a/core/app/alarm/mqtt/on_status_update.py
+++ b/core/app/alarm/mqtt/on_status_update.py
@@ -1,3 +1,5 @@
+from typing import Optional
+from devices.models import Device
 from alarm.models import AlarmStatus
 from alarm.use_cases.alarm_status import AlarmChangeStatus
 from dataclasses import dataclass, field
@@ -10,15 +12,23 @@ class UpdateStatusPayload:
     status: str
     force: str = 'off'
 
-    status_bool: bool = field(init=False)
-    force_bool: bool = field(init=False)
+    status_bool: Optional[bool] = field(init=False, default=None)
+    force_bool: Optional[bool] = field(init=False, default=None)
+    toggle: Optional[bool] = field(init=False, default=None)
 
     def __post_init__(self):
-        self.status_bool = strtobool(self.status) == 1
-        self.force_bool = strtobool(self.force) == 1 
+        if self.status == 'toggle':
+            self.toggle = True
+        else:
+            self.status_bool = strtobool(self.status) == 1
+            self.force_bool = strtobool(self.force) == 1 
 
 
 class OnUpdateStatus(OnUpdateStatusHandler):
+
+    def on_toggle_device(self, data_payload, device_id: str) -> None:
+        device = Device.objects.get(device_id=device_id)
+        AlarmChangeStatus.reverse_status(device.alarmstatus.pk, force=data_payload.force_bool)
 
     def on_update_device(self, data_payload, device_id: str) -> None:
         alarm_status = AlarmStatus.objects.get(device__device_id=device_id)

--- a/core/app/alarm/mqtt/on_status_update.py
+++ b/core/app/alarm/mqtt/on_status_update.py
@@ -1,0 +1,33 @@
+
+from alarm.models import AlarmStatus
+from alarm.use_cases.alarm_status import AlarmChangeStatus
+from dataclasses import dataclass, field
+from distutils.util import strtobool
+from utils.mqtt.mqtt_update_status import OnUpdateStatusHandler
+
+
+@dataclass
+class UpdateStatusPayload:
+    status: str
+    force: str
+
+    status_bool: bool = field(init=False)
+    force_bool: bool = field(init=False)
+
+    def __post_init__(self):
+        self.status_bool = strtobool(self.status) == 1
+        self.force_bool = strtobool(self.force) == 1 
+
+
+class OnUpdateStatus(OnUpdateStatusHandler):
+
+    @abstractmethod
+    def on_update_device(self, data_payload, device_id: str) -> None:
+        alarm_status = AlarmStatus.objects.get(device__device_id=device_id)
+        alarm_status.running = data_payload.status_bool
+        AlarmChangeStatus.save_status(alarm_status)
+
+    @abstractmethod
+    def on_update_all(self, data_payload: UpdateStatusPayload) -> None:
+        AlarmChangeStatus.all_change_status(status=data_payload.status_bool, force=data_payload.force_bool)
+

--- a/core/app/alarm/mqtt/on_status_update.py
+++ b/core/app/alarm/mqtt/on_status_update.py
@@ -1,4 +1,3 @@
-
 from alarm.models import AlarmStatus
 from alarm.use_cases.alarm_status import AlarmChangeStatus
 from dataclasses import dataclass, field
@@ -9,7 +8,7 @@ from utils.mqtt.mqtt_update_status import OnUpdateStatusHandler
 @dataclass
 class UpdateStatusPayload:
     status: str
-    force: str
+    force: str = 'off'
 
     status_bool: bool = field(init=False)
     force_bool: bool = field(init=False)
@@ -21,13 +20,11 @@ class UpdateStatusPayload:
 
 class OnUpdateStatus(OnUpdateStatusHandler):
 
-    @abstractmethod
     def on_update_device(self, data_payload, device_id: str) -> None:
         alarm_status = AlarmStatus.objects.get(device__device_id=device_id)
         alarm_status.running = data_payload.status_bool
-        AlarmChangeStatus.save_status(alarm_status)
+        AlarmChangeStatus.save_status(alarm_status, force=data_payload.force_bool)
 
-    @abstractmethod
     def on_update_all(self, data_payload: UpdateStatusPayload) -> None:
         AlarmChangeStatus.all_change_status(status=data_payload.status_bool, force=data_payload.force_bool)
 

--- a/core/app/alarm/tests/test_on_update_status.py
+++ b/core/app/alarm/tests/test_on_update_status.py
@@ -1,0 +1,31 @@
+from alarm.models import AlarmStatus
+from alarm.factories import AlarmStatusFactory
+from unittest.mock import patch
+from django.test import TestCase
+from alarm.mqtt.on_status_update import OnUpdateStatus, UpdateStatusPayload
+
+
+class OnUpdateStatusTestCase(TestCase):
+    def setUp(self) -> None:
+        self.update = OnUpdateStatus()
+
+    @patch('alarm.mqtt.on_status_update.AlarmChangeStatus')
+    def test_specific_device(self, alarm_change_status_mock):
+        self.alarm_status = AlarmStatusFactory()
+        device_id = self.alarm_status.device.device_id
+        data_payload = UpdateStatusPayload(status='on', force='on')
+        self.update.on_update_device(data_payload, device_id=device_id)
+        
+        s =AlarmStatus.objects.get(device__device_id=device_id)
+        s.running = True
+        
+        alarm_change_status_mock.save_status.assert_called_once_with(s, force=True)
+        alarm_change_status_mock.all_change_status.assert_not_called()
+        
+
+    @patch('alarm.mqtt.on_status_update.AlarmChangeStatus')
+    def test_all_device(self, alarm_change_status_mock):
+        data_payload = UpdateStatusPayload(status='on', force='on')
+        self.update.on_update_all(data_payload)
+        alarm_change_status_mock.all_change_status.assert_called_once_with(status=True, force=True)
+        alarm_change_status_mock.save_status.assert_not_called()

--- a/core/app/alarm/tests/test_on_update_status.py
+++ b/core/app/alarm/tests/test_on_update_status.py
@@ -10,13 +10,24 @@ class OnUpdateStatusTestCase(TestCase):
         self.update = OnUpdateStatus()
 
     @patch('alarm.mqtt.on_status_update.AlarmChangeStatus')
+    def test_toggle(self, alarm_change_status_mock):
+        alarm_status = AlarmStatusFactory()
+        device_id = alarm_status.device.device_id
+
+        data_payload = UpdateStatusPayload(status='toggle')
+        self.update.on_toggle_device(data_payload, device_id=device_id)
+
+        alarm_change_status_mock.reverse_status.assert_called_once_with(alarm_status.pk, force=False)
+
+
+    @patch('alarm.mqtt.on_status_update.AlarmChangeStatus')
     def test_specific_device(self, alarm_change_status_mock):
         self.alarm_status = AlarmStatusFactory()
         device_id = self.alarm_status.device.device_id
         data_payload = UpdateStatusPayload(status='on', force='on')
         self.update.on_update_device(data_payload, device_id=device_id)
         
-        s =AlarmStatus.objects.get(device__device_id=device_id)
+        s = AlarmStatus.objects.get(device__device_id=device_id)
         s.running = True
         
         alarm_change_status_mock.save_status.assert_called_once_with(s, force=True)

--- a/core/app/alarm/use_cases/alarm_status.py
+++ b/core/app/alarm/use_cases/alarm_status.py
@@ -3,7 +3,7 @@ from typing import List
 
 from django.db import transaction
 from alarm.use_cases.out_alarm import notify_alarm_status_factory
-from alarm.models import AlarmStatus, AlarmSchedule, Ping
+from alarm.models import AlarmStatus, AlarmSchedule
 
 
 def alarm_status_changed(alarm_status: AlarmStatus, force=False):
@@ -62,10 +62,10 @@ class AlarmChangeStatus:
             change_status(alarm_statuses, status, force)
 
     @staticmethod
-    def save_status(alarm_status: AlarmStatus) -> AlarmStatus:
+    def save_status(alarm_status: AlarmStatus, force: bool = False) -> AlarmStatus:
         with transaction.atomic():
             alarm_status.save()
-            change_status([alarm_status], alarm_status.running, force=False)
+            change_status([alarm_status], alarm_status.running, force=force)
 
             return alarm_status
 

--- a/core/app/automation/models.py
+++ b/core/app/automation/models.py
@@ -41,3 +41,5 @@ class ActionMqttPublish(models.Model):
             editable=False,
             help_text=_('Datetime that the automation last triggered the action to run. '))
 
+    def __str__(self):
+        return _('Publish to %(topic)s') % self.__dict__

--- a/core/app/standalone/mqtt/mqtt_run.py
+++ b/core/app/standalone/mqtt/mqtt_run.py
@@ -5,13 +5,15 @@ from utils.django.standalone_init import init
 init()
 
 from utils.mqtt.mqtt_status_handler import on_connected_services
+from utils.mqtt.mqtt_update_status import on_updates
 from utils.mqtt import mqtt_factory  # noqa: E402
-from alarm.mqtt import SERVICES  # noqa: E402
+from alarm.mqtt import SERVICES, UPDATES  # noqa: E402
 from alarm.mqtt.mqtt_controller import register
 
 mqtt = mqtt_factory(client_id='python_process_mqtt')
 
 on_connected_services(mqtt, SERVICES)
+on_updates(mqtt, UPDATES)
 register(mqtt)
 
 mqtt.client.loop_forever()

--- a/core/app/standalone/mqtt/mqtt_run.py
+++ b/core/app/standalone/mqtt/mqtt_run.py
@@ -6,8 +6,9 @@ init()
 
 from utils.mqtt.mqtt_status_handler import on_connected_services
 from utils.mqtt.mqtt_update_status import on_updates
-from utils.mqtt import mqtt_factory  # noqa: E402
-from alarm.mqtt import SERVICES, UPDATES  # noqa: E402
+from utils.mqtt import mqtt_factory
+from alarm.mqtt.mqtt_updates import UPDATES
+from alarm.mqtt import SERVICES 
 from alarm.mqtt.mqtt_controller import register
 
 mqtt = mqtt_factory(client_id='python_process_mqtt')

--- a/core/app/utils/mqtt/mqtt_update_status.py
+++ b/core/app/utils/mqtt/mqtt_update_status.py
@@ -1,0 +1,77 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional, Sequence, Type, TypeVar
+from utils.mqtt import MQTT
+from utils.mqtt.mqtt_data import MqttMessage, MqttTopicSubscriptionJson
+from distutils.util import strtobool
+import re
+
+
+@dataclass
+class TopicMatcher:
+    _topic_matcher: str
+
+
+T = TypeVar('T')
+
+
+def topic_regex(topic: str, t: T) -> T:
+    match = re.match(t._topic_matcher, topic)
+
+    if match:
+        groups = match.groupdict()
+        return t(**groups) # type: ignore
+
+    raise ValueError(f'topic {topic} wrong format. {t._topic_matcher}')
+
+class OnUpdateStatusHandler(ABC):
+ 
+    @abstractmethod
+    def on_update_device(self, payload, device_id: str) -> None:
+        pass
+
+    @abstractmethod
+    def on_update_all(self, payload) -> None:
+        pass
+
+
+@dataclass
+class UpdateStatusTopic:
+    service: str
+    device_id: Optional[str] = None
+
+    _topic_matcher: str = r"^(?P<service>[\w]+)/(?P<device_id>[\w]+)"
+
+
+class OnUpdate:
+    def __init__(self, handler: OnUpdateStatusHandler, payload: Type[Any]) -> None:
+        self._handler = handler
+        self._payload_type = payload
+
+    def on_update(self, message: MqttMessage) -> None:
+        topic = topic_regex(message.topic, UpdateStatusTopic)
+        data_payload = self._payload_type(**message.payload)
+
+        if topic.device_id is not None:
+            self._handler.on_update_device(data_payload, topic.device_id)
+        else:
+            self._handler.on_update_all(data_payload)
+
+
+@dataclass
+class UpdateStatusDescriptor:
+    name: str
+    on_update: Type[OnUpdateStatusHandler]
+    payload_type: Type[Any]
+
+
+def bind_on_update(service_name: str, handler_instance: OnUpdateStatusHandler, payload_type) -> MqttTopicSubscriptionJson:
+    on_update = OnUpdate(handler_instance, payload_type)
+
+    return MqttTopicSubscriptionJson(f'connected/{service_name}/+', on_update.on_update)
+
+
+def on_updates(mqtt: MQTT, services: Sequence[UpdateStatusDescriptor]) -> None:
+    subscriptions = [bind_on_update(service.name, service.on_update(), service.payload_type) for service in services]
+    mqtt.add_subscribe(subscriptions) 
+ 

--- a/core/app/utils/mqtt/mqtt_update_status.py
+++ b/core/app/utils/mqtt/mqtt_update_status.py
@@ -25,6 +25,9 @@ def topic_regex(topic: str, t: T) -> T:
     raise ValueError(f'topic {topic} wrong format. {t._topic_matcher}')
 
 class OnUpdateStatusHandler(ABC):
+    @abstractmethod
+    def on_toggle_device(self, data_payload, device_id: str) -> None:
+        pass
  
     @abstractmethod
     def on_update_device(self, payload, device_id: str) -> None:
@@ -51,6 +54,12 @@ class OnUpdate:
     def on_update(self, message: MqttMessage) -> None:
         topic = topic_regex(message.topic, UpdateStatusTopic)
         data_payload = self._payload_type(**message.payload)
+
+        if data_payload.toggle is True:
+            if not topic.device_id:
+                raise ValueError(f'device_id in topic is mandatory to toggle got {message.topic}')
+
+            self._handler.on_toggle_device(data_payload, topic.device_id)
 
         if topic.device_id is not None:
             self._handler.on_update_device(data_payload, topic.device_id)

--- a/core/app/utils/mqtt/mqtt_update_status.py
+++ b/core/app/utils/mqtt/mqtt_update_status.py
@@ -60,6 +60,7 @@ class OnUpdate:
                 raise ValueError(f'device_id in topic is mandatory to toggle got {message.topic}')
 
             self._handler.on_toggle_device(data_payload, topic.device_id)
+            return None
 
         if topic.device_id is not None:
             self._handler.on_update_device(data_payload, topic.device_id)

--- a/core/app/utils/mqtt/mqtt_update_status.py
+++ b/core/app/utils/mqtt/mqtt_update_status.py
@@ -40,7 +40,7 @@ class UpdateStatusTopic:
     service: str
     device_id: Optional[str] = None
 
-    _topic_matcher: str = r"^(?P<service>[\w]+)/(?P<device_id>[\w]+)"
+    _topic_matcher: str = r"^update\/(?P<service>[\w]+)(?:\/(?P<device_id>[\w]+)?)?"
 
 
 class OnUpdate:
@@ -68,7 +68,7 @@ class UpdateStatusDescriptor:
 def bind_on_update(service_name: str, handler_instance: OnUpdateStatusHandler, payload_type) -> MqttTopicSubscriptionJson:
     on_update = OnUpdate(handler_instance, payload_type)
 
-    return MqttTopicSubscriptionJson(f'connected/{service_name}/+', on_update.on_update)
+    return MqttTopicSubscriptionJson(f'update/{service_name}/+', on_update.on_update)
 
 
 def on_updates(mqtt: MQTT, services: Sequence[UpdateStatusDescriptor]) -> None:

--- a/core/app/utils/mqtt/tests/test_mqtt_update_status.py
+++ b/core/app/utils/mqtt/tests/test_mqtt_update_status.py
@@ -129,12 +129,17 @@ class OnUpdateMqttSubscribeTestCase(TestCase):
     def test_mqtt_subscribe(self):
         call_param = []
         for service in self.updates:
-            p = MqttTopicSubscriptionJson(
+            call_param.append(MqttTopicSubscriptionJson(
+                topic=f'update/{service.name}',
+                _callback=ANY,
+                qos=1
+            ))
+
+            call_param.append(MqttTopicSubscriptionJson(
                 topic=f'update/{service.name}/+',
                 _callback=ANY,
                 qos=1
-            )
-            call_param.append(p)
+            ))
 
         on_updates(self.mqtt, self.updates)
         self.mqtt.add_subscribe.assert_called_once_with(call_param)

--- a/core/app/utils/mqtt/tests/test_mqtt_update_status.py
+++ b/core/app/utils/mqtt/tests/test_mqtt_update_status.py
@@ -43,6 +43,47 @@ class MqttUpdateStatusTestCase(TestCase):
         self.handler_mock.on_update_all.assert_not_called()
         self.handler_mock.on_update_device.assert_called_once_with(expected_payload, self.device_id)
 
+    def test_on_update_toggle(self):
+        topic = f'update/{self.service_name}/{self.device_id}'
+
+        payload = {
+            'status': 'toggle'
+        }
+
+        message = MqttMessage(
+            topic,
+            payload,
+            self.qos,
+            self.retain,
+            topic,
+            self.timestamp,
+        )
+
+        expected_payload = UpdateStatusPayload(**message.payload)
+
+        self.on_update.on_update(message)
+        self.handler_mock.on_toggle_device.assert_called_once_with(expected_payload, self.device_id)
+
+
+    def test_on_update_toggle_raise(self):
+        topic = f'update/{self.service_name}'
+
+        payload = {
+            'status': 'toggle'
+        }
+
+        message = MqttMessage(
+            topic,
+            payload,
+            self.qos,
+            self.retain,
+            topic,
+            self.timestamp,
+        )
+
+        with self.assertRaises(ValueError) as _context:
+            self.on_update.on_update(message)
+
     def test_on_update_all(self):
         topic = f'update/{self.service_name}'
 

--- a/core/app/utils/mqtt/tests/test_mqtt_update_status.py
+++ b/core/app/utils/mqtt/tests/test_mqtt_update_status.py
@@ -40,6 +40,7 @@ class MqttUpdateStatusTestCase(TestCase):
         self.on_update.on_update(message)
 
         expected_payload = UpdateStatusPayload(**message.payload)
+        self.handler_mock.on_toggle_device.assert_not_called()
         self.handler_mock.on_update_all.assert_not_called()
         self.handler_mock.on_update_device.assert_called_once_with(expected_payload, self.device_id)
 
@@ -63,6 +64,8 @@ class MqttUpdateStatusTestCase(TestCase):
 
         self.on_update.on_update(message)
         self.handler_mock.on_toggle_device.assert_called_once_with(expected_payload, self.device_id)
+        self.handler_mock.on_update_all.assert_not_called()
+        self.handler_mock.on_update_device.assert_not_called()
 
 
     def test_on_update_toggle_raise(self):
@@ -83,6 +86,9 @@ class MqttUpdateStatusTestCase(TestCase):
 
         with self.assertRaises(ValueError) as _context:
             self.on_update.on_update(message)
+        self.handler_mock.on_update_all.assert_not_called()
+        self.handler_mock.on_toggle_device.assert_not_called()
+        self.handler_mock.on_update_device.assert_not_called()
 
     def test_on_update_all(self):
         topic = f'update/{self.service_name}'
@@ -105,6 +111,7 @@ class MqttUpdateStatusTestCase(TestCase):
         expected_payload = UpdateStatusPayload(**message.payload)
         self.handler_mock.on_update_all.assert_called_once_with(expected_payload)
         self.handler_mock.on_update_device.assert_not_called()
+        self.handler_mock.on_toggle_device.assert_not_called()
 
 
 class OnUpdateMqttSubscribeTestCase(TestCase):

--- a/core/app/utils/mqtt/tests/test_mqtt_update_status.py
+++ b/core/app/utils/mqtt/tests/test_mqtt_update_status.py
@@ -1,0 +1,66 @@
+
+from alarm.mqtt.on_status_update import UpdateStatusPayload
+from unittest.mock import Mock
+from utils.mqtt.mqtt_data import MqttMessage
+from utils.mqtt.mqtt_update_status import OnUpdate
+from devices.factories import DeviceFactory
+from django.test.testcases import TestCase
+import utils.date as dt_utils
+
+
+class MqttUpdateStatusTestCase(TestCase):
+    def setUp(self) -> None:
+        self.device = DeviceFactory()
+        self.service_name = 'some_service_name'
+        self.device_id = self.device.device_id
+        self.retain = False
+        self.qos = 1
+
+        self.timestamp = dt_utils.utcnow()
+
+        self.handler_mock = Mock()
+        self.on_update = OnUpdate(self.handler_mock, payload=UpdateStatusPayload)
+
+    def test_on_update_device(self):
+        topic = f'update/{self.service_name}/{self.device_id}'
+
+        payload = {
+            'status': 'off'
+        }
+
+        message = MqttMessage(
+            topic,
+            payload,
+            self.qos,
+            self.retain,
+            topic,
+            self.timestamp,
+        )
+
+        self.on_update.on_update(message)
+
+        expected_payload = UpdateStatusPayload(**message.payload)
+        self.handler_mock.on_update_all.assert_not_called()
+        self.handler_mock.on_update_device.assert_called_once_with(expected_payload, self.device_id)
+
+    def test_on_update_all(self):
+        topic = f'update/{self.service_name}'
+
+        payload = {
+            'status': 'off'
+        }
+
+        message = MqttMessage(
+            topic,
+            payload,
+            self.qos,
+            self.retain,
+            topic,
+            self.timestamp,
+        )
+
+        self.on_update.on_update(message)
+
+        expected_payload = UpdateStatusPayload(**message.payload)
+        self.handler_mock.on_update_all.assert_called_once_with(expected_payload)
+        self.handler_mock.on_update_device.assert_not_called()

--- a/core/config/mosquitto/mosquitto.conf
+++ b/core/config/mosquitto/mosquitto.conf
@@ -1,4 +1,5 @@
 listener 8883
+listener 1883
 
 password_file /mosquitto/config/passwd
 allow_anonymous true


### PR DESCRIPTION
```
mosquitto_pub -h mqtt_broker -p 1883 -t update/alarm -m '{"status": "on"}' -u mx -P coucou
mosquitto_pub -h mqtt_broker -p 1883 -t update/alarm -m '{"status": "off"}' -u mx -P coucou

mosquitto_pub -h mqtt_broker -p 1883 -t update/alarm/device_id -m '{"status": "toggle"}' -u mx -P coucou
mosquitto_pub -h mqtt_broker -p 1883 -t update/alarm/device_id -m '{"status": "on"}' -u mx -P coucou
mosquitto_pub -h mqtt_broker -p 1883 -t update/alarm/device_id -m '{"status": "off"}' -u mx -P coucou
```