### PR TITLE
feat(core): mqtt bool payload parse accepts string and byte

### DIFF
--- a/core/app/utils/mqtt/tests/test_mqtt_data.py
+++ b/core/app/utils/mqtt/tests/test_mqtt_data.py
@@ -36,6 +36,36 @@ class MqttTopicSubscriptionBooleanTestCase(TestCase):
         ))
         self.callback_mock.assert_not_called()
 
+    def test_call_string_bool_true(self):
+        self.subscription.callback(MqttMessage(
+            f'connected/{self.service_name}',
+            b"1",
+            1,
+            False,
+        ))
+
+        self.callback_mock.assert_called_once_with(MqttMessage(
+            f'connected/{self.service_name}',
+            True,
+            1,
+            False,
+        ))
+
+    def test_call_string_bool_false(self):
+        self.subscription.callback(MqttMessage(
+            f'connected/{self.service_name}',
+            b"0",
+            1,
+            False,
+        ))
+
+        self.callback_mock.assert_called_once_with(MqttMessage(
+            f'connected/{self.service_name}',
+            False,
+            1,
+            False,
+        ))
+
 class MqttTopicSubscriptionJsonTestCase(TestCase):
     def setUp(self) -> None:
         self.service_name = 'some service'


### PR DESCRIPTION
Before this it was only accepting 0x00 (false) and 0x01 (true).
I added this because I did not find any solution to send these bytes for will message with the PubSub library used by the espcam.
It adds complexity that I don't wanted but its well tested and as of today I don't have other choice, will message is necessary to know either or not the esp is still responding. Thus it adds flexibility that could be neat.