### PR TITLE
wip feat(core): mqtt camera status add "support_video" prop

### DIFF
--- a/core/app/alarm/messaging.py
+++ b/core/app/alarm/messaging.py
@@ -15,18 +15,28 @@ class SpeakerMessaging:
 
 class AlarmMessaging:
     """Class to communicate with Alarm services (through mqtt).
-
     """
     def __init__(self, mqtt_status: MqttJsonStatus, speaker_messaging: SpeakerMessaging, camera_messaging: CameraMessaging):
         self._mqtt_status = mqtt_status
         self._speaker_messaging = speaker_messaging
         self._camera_messaging = camera_messaging
 
-    def publish_alarm_status(self, device_id: str, status: bool, is_dumb: bool, data=None) -> None:
-        self._mqtt_status.publish(f'status/{MqttServices.OBJECT_DETECTION_MANAGER.value}/{device_id}', status, data)
+    def publish_alarm_status(self, device_id: str, device_type: str, status: bool) -> None:
+        # why 2 publish call????
+        # I guess it's because I can stream my camera without starting up the object_detection for it.
+        # but in this case, I could use the same topic because I have the info, "to_analyze",
+        # if set to False, don't start a new object detection object for it.
 
-        camera_cara = CameraData(to_analyze=True) if status else CameraData(to_analyze=False)
-        self._camera_messaging.publish_status(device_id, status, camera_cara)
+        # todo: check if device supports video, if not flag it.
+        camera_data = CameraData(to_analyze=True) if status else CameraData(to_analyze=False)
+        
+        if device_type == 'esp32cam':
+            camera_data.video_spport = False
+
+        self._mqtt_status.publish(f'status/{MqttServices.OBJECT_DETECTION_MANAGER.value}/{device_id}', status, camera_data)
+
+        # will send to camera_manager
+        self._camera_messaging.publish_status(device_id, status, camera_data)
 
         if status is False:
             self._speaker_messaging.publish_speaker_status(device_id, False)

--- a/core/app/alarm/messaging.py
+++ b/core/app/alarm/messaging.py
@@ -31,9 +31,9 @@ class AlarmMessaging:
         camera_data = CameraData(to_analyze=True) if status else CameraData(to_analyze=False)
         
         if device_type == 'esp32cam':
-            camera_data.video_spport = False
+            camera_data.video_support = False
 
-        self._mqtt_status.publish(f'status/{MqttServices.OBJECT_DETECTION_MANAGER.value}/{device_id}', status, camera_data)
+        #self._mqtt_status.publish(f'status/{MqttServices.OBJECT_DETECTION_MANAGER.value}/{device_id}', status, camera_data)
 
         # will send to camera_manager
         self._camera_messaging.publish_status(device_id, status, camera_data)

--- a/core/app/alarm/tests/test_alarm_messaging.py
+++ b/core/app/alarm/tests/test_alarm_messaging.py
@@ -26,17 +26,17 @@ class AlarmMessagingTestCase(TestCase):
         self.speaker_messaging.publish_speaker_status.assert_not_called()
 
     def test_camera_publish_true_status(self):
-        data = CameraData(to_analyze=True, stream=None, video_spport=None)
+        data = CameraData(to_analyze=True, stream=None, video_support=None)
         self.alarm.publish_alarm_status(self.device_id, self.device_type, True)
         self.camera_messaging.publish_status.assert_called_once_with(self.device_id, True, data)
 
     def test_camera_publish_false_status(self):
-        data = CameraData(to_analyze=False, stream=None, video_spport=None)
+        data = CameraData(to_analyze=False, stream=None, video_support=None)
         self.alarm.publish_alarm_status(self.device_id, self.device_type, False)
         self.camera_messaging.publish_status.assert_called_once_with(self.device_id, False, data)
 
     def test_camera_publish_esp_edge_case(self):
-        data = CameraData(to_analyze=True, stream=None, video_spport=False)
+        data = CameraData(to_analyze=True, stream=None, video_support=False)
         self.alarm.publish_alarm_status(self.device_id, 'esp32cam', True)
         self.camera_messaging.publish_status.assert_called_once_with(self.device_id, True, data)
 

--- a/core/app/alarm/tests/test_alarm_messaging.py
+++ b/core/app/alarm/tests/test_alarm_messaging.py
@@ -1,3 +1,4 @@
+from camera.messaging import CameraData
 from unittest.mock import Mock
 from django.test import TestCase
 
@@ -8,6 +9,7 @@ from utils.mqtt.mqtt_status import MqttJsonStatus
 class AlarmMessagingTestCase(TestCase):
     def setUp(self) -> None:
         self.device_id = '123456'
+        self.device_type = 'pi0'
         self.mqtt_mock = Mock()
         self.speaker_messaging = Mock()
         self.camera_messaging = Mock()
@@ -16,9 +18,26 @@ class AlarmMessagingTestCase(TestCase):
         self.alarm = AlarmMessaging(self.json_status, self.speaker_messaging, self.camera_messaging)
 
     def test_synchronize_sound(self):
-        self.alarm.publish_alarm_status(self.device_id, False, False)
+        self.alarm.publish_alarm_status(self.device_id, self.device_type, False)
         self.speaker_messaging.publish_speaker_status.assert_called_once_with(self.device_id, False)
 
     def test_no_synchronize_sound(self):
-        self.alarm.publish_alarm_status(self.device_id, True, False)
+        self.alarm.publish_alarm_status(self.device_id, self.device_type, True)
         self.speaker_messaging.publish_speaker_status.assert_not_called()
+
+    def test_camera_publish_true_status(self):
+        data = CameraData(to_analyze=True, stream=None, video_spport=None)
+        self.alarm.publish_alarm_status(self.device_id, self.device_type, True)
+        self.camera_messaging.publish_status.assert_called_once_with(self.device_id, True, data)
+
+    def test_camera_publish_false_status(self):
+        data = CameraData(to_analyze=False, stream=None, video_spport=None)
+        self.alarm.publish_alarm_status(self.device_id, self.device_type, False)
+        self.camera_messaging.publish_status.assert_called_once_with(self.device_id, False, data)
+
+    def test_camera_publish_esp_edge_case(self):
+        data = CameraData(to_analyze=True, stream=None, video_spport=False)
+        self.alarm.publish_alarm_status(self.device_id, 'esp32cam', True)
+        self.camera_messaging.publish_status.assert_called_once_with(self.device_id, True, data)
+
+

--- a/core/app/alarm/tests/test_notify_alarm.py
+++ b/core/app/alarm/tests/test_notify_alarm.py
@@ -23,8 +23,7 @@ class NotifyAlarmStatusTestCase(TestCase):
         self.alarm_messaging_mock = Mock()
 
     def _except_publish_alarm_status_call(self):
-        expected_payload = {'is_dumb': self.alarm_status.is_dumb}
-        expected_calls = [call(self.device.device_id, self.alarm_status.running, self.alarm_status.is_dumb, expected_payload)]
+        expected_calls = [call(self.device.device_id, self.alarm_status.device.device_type.type, self.alarm_status.running)]
         self.alarm_messaging_mock.publish_alarm_status.assert_has_calls(expected_calls)
 
     def test_publish_false(self):

--- a/core/app/alarm/use_cases/camera_motion.py
+++ b/core/app/alarm/use_cases/camera_motion.py
@@ -1,7 +1,7 @@
 import logging
 import automation.tasks as automation_tasks
 from devices.models import Device
-from alarm.use_cases.data import InMotionCameraData 
+from alarm.use_cases.data import InMotionCameraData
 import alarm.business.in_motion as in_motion
 import alarm.use_cases.out_alarm as out_alarm
 from alarm.use_cases.play_sound import play_sound
@@ -27,7 +27,7 @@ def camera_motion_detected(data: InMotionCameraData) -> None:
     else:
         alarm_notifications.object_no_more_detected(device)
         automation_tasks.on_motion_left.apply_async(kwargs={'device_id': device.device_id})
-        
+
         alarm_status = AlarmStatus.objects.get(device=device)
         if alarm_status.running is False:
             LOGGER.info(f'The alarm on device {device.device_id} did not turn off because a motion was here. Not here anymore, turning off.')
@@ -35,4 +35,3 @@ def camera_motion_detected(data: InMotionCameraData) -> None:
             out_alarm.notify_alarm_status_factory().publish_status_changed(device.pk, alarm_status)
 
     play_sound(data.device_id, data.status)
-

--- a/core/app/alarm/use_cases/out_alarm.py
+++ b/core/app/alarm/use_cases/out_alarm.py
@@ -15,6 +15,11 @@ LOGGER = logging.getLogger(__name__)
 
 
 class NotifyAlarmStatus:
+    """Class to coordinate the communication with alarm.
+    Methods to call when you need to communicate with an alarm.
+    It will takes decision and call
+    the underlying methods to actually send messages with corresponding data.
+    """
     def __init__(self, alarm_messaging: AlarmMessaging):
         self._alarm_messaging = alarm_messaging
 
@@ -23,10 +28,6 @@ class NotifyAlarmStatus:
         The only method that actually send an mqtt message.
         It formats the mqtt payload and decide whether or not a mqtt call has to be done.
         """
-        payload = {
-            'is_dumb': status.is_dumb
-        }
-
         if status.running is False and alarm_status.can_turn_off(device) is False and force is False:
             LOGGER.info(f'The alarm on device {device.device_id} should turn off but stay on because a motion is being detected.')
             return
@@ -34,7 +35,7 @@ class NotifyAlarmStatus:
         checks.verify_services_status(device.device_id, status.running, status.is_dumb)
 
         self._alarm_messaging \
-            .publish_alarm_status(device.device_id, status.running, status.is_dumb, payload)
+            .publish_alarm_status(device.device_id, device.device_type.type, status.running)
 
     def _publish_alarm_status_with_config(self, device: Device, status: AlarmStatus, force=False) -> None:
         self._publish(device, status, force)

--- a/core/app/camera/messaging.py
+++ b/core/app/camera/messaging.py
@@ -9,7 +9,7 @@ from utils.mqtt.mqtt_status import MqttJsonStatus
 class CameraData:
     to_analyze: Optional[bool] = None
     stream: Optional[bool] = None
-    video_spport: Optional[bool] = None
+    video_support: Optional[bool] = None
 
 
 class CameraMessaging:

--- a/core/app/camera/messaging.py
+++ b/core/app/camera/messaging.py
@@ -9,6 +9,7 @@ from utils.mqtt.mqtt_status import MqttJsonStatus
 class CameraData:
     to_analyze: Optional[bool] = None
     stream: Optional[bool] = None
+    video_spport: Optional[bool] = None
 
 
 class CameraMessaging:

--- a/smart-camera/app/camera/camera_object_detection_factory.py
+++ b/smart-camera/app/camera/camera_object_detection_factory.py
@@ -3,13 +3,12 @@ from typing import Optional
 from object_detection.detect_people import DetectPeople
 from object_detection.detect_people_factory import detect_people_factory
 from .camera_object_detection import CameraObjectDetection
-from .camera_record import CameraRecorder
 from .camera_recording import CameraRecording
 from mqtt.mqtt_client import get_mqtt
 
 
-def camera_object_detection_factory(device_id: str, camera_recorder: CameraRecorder, detect_people: Optional[DetectPeople] = None) -> CameraObjectDetection:
+def camera_object_detection_factory(device_id: str, camera_recording: CameraRecording, detect_people: Optional[DetectPeople] = None) -> CameraObjectDetection:
     if detect_people is None:
         detect_people = detect_people_factory()
 
-    return CameraObjectDetection(detect_people, get_mqtt, device_id, CameraRecording(device_id, camera_recorder))
+    return CameraObjectDetection(detect_people, get_mqtt, device_id, camera_recording)

--- a/smart-camera/app/listen_frame.py
+++ b/smart-camera/app/listen_frame.py
@@ -47,6 +47,6 @@ mqtt_client.connect()
 
 # topics to know when a camera is up/off
 camera_manager = RunListenFrame(connected_devices)
-MqttManageRunnable(DEVICE_ID, 'object_detection_manager', get_mqtt(f'{DEVICE_ID}-object_detection_manager'), camera_manager, status_json=True, multi_device=True)
+MqttManageRunnable(DEVICE_ID, 'camera_manager', get_mqtt(f'{DEVICE_ID}-object_detection_manager'), camera_manager, status_json=True, multi_device=True)
 
 mqtt_client.client.loop_forever()

--- a/smart-camera/app/test/test_connected_devices.py
+++ b/smart-camera/app/test/test_connected_devices.py
@@ -1,0 +1,30 @@
+
+from camera.camera_recording import CameraRecording, NoCameraRecording
+from camera.camera_record import DumbCameraRecorder
+from unittest.mock import Mock, patch
+from service_manager.run_listen_frame import ConnectedDevices
+from unittest.case import TestCase
+
+
+class ConnectedDevicesTestCase(TestCase):
+    def setUp(self) -> None:
+        self.device_id = 'fake_device_id'
+        self.mqtt_mock = Mock()
+        self.connected_devices = ConnectedDevices(self.mqtt_mock)
+
+    @patch('service_manager.run_listen_frame.camera_object_detection_factory')
+    def test_factory_with_video_support(self, factory_mock):
+        self.connected_devices.add(self.device_id, True)
+        factory_mock.assert_called_once()
+        
+        args = factory_mock.call_args_list[0][0]
+        self.assertIsInstance(args[1], CameraRecording)
+
+    @patch('service_manager.run_listen_frame.camera_object_detection_factory')
+    def test_factory_without_video_support(self, factory_mock):
+        self.connected_devices.add(self.device_id, False)
+        factory_mock.assert_called_once()
+        
+        args = factory_mock.call_args_list[0][0]
+        self.assertIsInstance(args[1], NoCameraRecording)
+

--- a/smart-camera/app/test/test_run_listen_frame.py
+++ b/smart-camera/app/test/test_run_listen_frame.py
@@ -9,13 +9,13 @@ class RunListenFrameTestCase(TestCase):
         self.connected_devices = Mock()
         self.runnable = RunListenFrame(self.connected_devices)
         self.device_id = 'some_device_id'
-        self.payload = {}
+        self.payload = {'to_analyze': True}
 
     def test_add_device(self):
         self.connected_devices.has.return_value = False
 
         self.runnable.run(self.device_id, True, self.payload) 
-        self.connected_devices.add.assert_called_once_with(self.device_id)
+        self.connected_devices.add.assert_called_once_with(self.device_id, True)
 
         self.connected_devices.has.return_value = True
         self.runnable.run(self.device_id, True, self.payload) 
@@ -24,3 +24,14 @@ class RunListenFrameTestCase(TestCase):
         self.runnable.run(self.device_id, False, self.payload) 
         self.connected_devices.remove.assert_called_once_with(self.device_id)
 
+    def test_dont_add_device(self):
+        self.connected_devices.has.return_value = False
+
+        self.runnable.run(self.device_id, True, {'to_analyze': False}) 
+        self.connected_devices.add.assert_not_called()
+
+    def test_add_with_video_support_param(self):
+        self.connected_devices.has.return_value = False
+
+        self.runnable.run(self.device_id, True, {'to_analyze': True, 'video_support': False}) 
+        self.connected_devices.add.assert_called_once_with(self.device_id, False)


### PR DESCRIPTION
Enabler for #235 

esp32 cam does not support video, so we need to know it and to communicate about it otherwise the `listen_frame` service will order to manage videos resulting in exceptions from the `core` (because it will try to retrieve videos from rsync).

This won't crashes anything because it's inside tasks but pollute logs.

So we need to say "this device does not support video" so the `listen_frame` skip the video management.

:warning: 10 August 2021:
I will integrate others cameras in which I won't have the control on the firmware. So basically, the video management will depends on the camera, some of them will have mqtt, others http... How can I manage this?

This is tricky because logic is inside the "object detection" service and not the core, so it does not have the whole information about the device. As of today, the logic is in this service because it's way simpler. It receives frames, check if peoples are detected, if so it decides to record video and manage the timing (after X seconds split, every X seconds split, stop).

This is a complex topic and it has been already discussed in issue #173

-> In the core app, when it receives message to indicates a video thing we need to have a switch according to the device type. It solves the issue.

Done in PR #243