### PR TITLE
feat(core): remove is dumb communication

### DIFF
--- a/core/app/alarm/messaging.py
+++ b/core/app/alarm/messaging.py
@@ -12,7 +12,7 @@ class AlarmMessaging:
         self._mqtt_status = mqtt_status
         self._camera_messaging = camera_messaging
 
-    def publish_alarm_status(self, device_id: str, status: bool, is_dumb: bool, data=None) -> None:
+    def publish_alarm_status(self, device_id: str, status: bool, data=None) -> None:
         self._mqtt_status.publish(f'status/{MqttServices.OBJECT_DETECTION_MANAGER.value}/{device_id}', status, data)
 
         camera_cara = CameraData(to_analyze=True) if status else CameraData(to_analyze=False)

--- a/core/app/alarm/tests/test_notify_alarm.py
+++ b/core/app/alarm/tests/test_notify_alarm.py
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 
 from alarm.use_cases.out_alarm import NotifyAlarmStatus
 from alarm.factories import AlarmStatusFactory
-from camera.factories import CameraROIFactoryConf 
+from camera.factories import CameraROIFactoryConf
 from alarm.models import AlarmStatus
 from camera.models import CameraMotionDetected
 from devices.models import Device
@@ -23,8 +23,8 @@ class NotifyAlarmStatusTestCase(TestCase):
         self.alarm_messaging_mock = Mock()
 
     def _except_publish_alarm_status_call(self):
-        expected_payload = {'is_dumb': self.alarm_status.is_dumb}
-        expected_calls = [call(self.device.device_id, self.alarm_status.running, self.alarm_status.is_dumb, expected_payload)]
+        expected_payload = {}
+        expected_calls = [call(self.device.device_id, self.alarm_status.running, expected_payload)]
         self.alarm_messaging_mock.publish_alarm_status.assert_has_calls(expected_calls)
 
     def test_publish_false(self):

--- a/core/app/alarm/tests/test_notify_alarm_status_verify.py
+++ b/core/app/alarm/tests/test_notify_alarm_status_verify.py
@@ -18,8 +18,8 @@ class NotifyAlarmStatusVerify(TestCase):
     @patch('mqtt_services.tasks.verify_service_status')
     def test_verify_service_status(self, verify_service_status):
         def _test(status: bool):
-            verify_services_status(self.device_id, status, False)
-            
+            verify_services_status(self.device_id, status)
+
             kwargs = {
                 'device_id': self.device_id,
                 'service_name': MqttServices.OBJECT_DETECTION.value,
@@ -33,7 +33,7 @@ class NotifyAlarmStatusVerify(TestCase):
                 'status': status,
                 'since_time': timezone.now()
             }
-            
+
             calls = [
                 call(kwargs=kwargs, countdown=15),
                 call(kwargs=kwargs2, countdown=15),

--- a/core/app/alarm/use_cases/checks.py
+++ b/core/app/alarm/use_cases/checks.py
@@ -3,7 +3,7 @@ import mqtt_services.tasks as tasks
 from alarm.mqtt import MqttServices, CameraMqttServices
 
 
-def verify_services_status(device_id: str, status: bool, is_dumb: bool) -> None:
+def verify_services_status(device_id: str, status: bool) -> None:
     """When the system turns on the camera, we verify that related services are up/off. It sends tasks to check that.
     """
 

--- a/core/app/alarm/use_cases/out_alarm.py
+++ b/core/app/alarm/use_cases/out_alarm.py
@@ -24,17 +24,16 @@ class NotifyAlarmStatus:
         It formats the mqtt payload and decide whether or not a mqtt call has to be done.
         """
         payload = {
-            'is_dumb': status.is_dumb
         }
 
         if status.running is False and alarm_status.can_turn_off(device) is False and force is False:
             LOGGER.info(f'The alarm on device {device.device_id} should turn off but stay on because a motion is being detected.')
             return
 
-        checks.verify_services_status(device.device_id, status.running, status.is_dumb)
+        checks.verify_services_status(device.device_id, status.running)
 
         self._alarm_messaging \
-            .publish_alarm_status(device.device_id, status.running, status.is_dumb, payload)
+            .publish_alarm_status(device.device_id, status.running, payload)
 
     def _publish_alarm_status_with_config(self, device: Device, status: AlarmStatus, force=False) -> None:
         self._publish(device, status, force)


### PR DESCRIPTION
Alarm messaging was sending is dumb boolean in the mqtt payload. It was used before but it's now useless.