### PR TITLE
chrore: django stubs for pyright checks

### DIFF
--- a/core/app/requirements.txt
+++ b/core/app/requirements.txt
@@ -14,3 +14,5 @@ django_extensions==3.0.9
 Pillow==8.1.*
 freezegun==1.0.0
 coverage==5.5
+django-stubs==1.8.0
+mypy==0.812

--- a/core/app/setup.cfg
+++ b/core/app/setup.cfg
@@ -1,0 +1,6 @@
+[mypy]
+plugins =
+    mypy_django_plugin.main
+
+[mypy.plugins.django-stubs]
+django_settings_module = "hello_django.settings"


### PR DESCRIPTION
- :warning: [install the right version of django stubs according to the mypy version. ](https://pypi.org/project/django-stubs/#description)
- found the solution: https://github.com/microsoft/pyright/issues/1359 I had the exact same issue.