### PR TITLE
feat(alarm): remove status check for object detection service

### DIFF
--- a/core/app/alarm/tests/test_notify_alarm_status_verify.py
+++ b/core/app/alarm/tests/test_notify_alarm_status_verify.py
@@ -20,13 +20,6 @@ class NotifyAlarmStatusVerify(TestCase):
         def _test(status: bool):
             verify_services_status(self.device_id, status)
 
-            kwargs = {
-                'device_id': self.device_id,
-                'service_name': MqttServices.OBJECT_DETECTION.value,
-                'status': status,
-                'since_time': timezone.now()
-            }
-
             kwargs2 = {
                 'device_id': self.device_id,
                 'service_name': CameraMqttServices.CAMERA.value,
@@ -35,7 +28,6 @@ class NotifyAlarmStatusVerify(TestCase):
             }
 
             calls = [
-                call(kwargs=kwargs, countdown=15),
                 call(kwargs=kwargs2, countdown=15),
             ]
 

--- a/core/app/alarm/use_cases/checks.py
+++ b/core/app/alarm/use_cases/checks.py
@@ -7,15 +7,6 @@ def verify_services_status(device_id: str, status: bool) -> None:
     """When the system turns on the camera, we verify that related services are up/off. It sends tasks to check that.
     """
 
-    kwargs = {
-        'device_id': device_id,
-        'service_name': MqttServices.OBJECT_DETECTION.value,
-        'status': status,
-        'since_time': timezone.now()
-    }
-
-    tasks.verify_service_status.apply_async(kwargs=kwargs, countdown=15)
-
     kwargs_dumb = {
         'device_id': device_id,
         'service_name': CameraMqttServices.CAMERA.value,


### PR DESCRIPTION
With the new service it stays opened. It doesn't open a new mqtt connection for a device when the alarm is on (and off when alarm is off).

- closes #266